### PR TITLE
add ability to specify vcl file to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ docker run -e VARNISH_BACKEND_ADDRESS=a.b.c.d \
            -Pit --name=varnish-alpine thiagofigueiro/varnish-alpine-docker
 ```
 
+Alternatively, specify a varnish config file
+
+```bash
+docker run -e VARNISH_CONFIG_FILE=/etc/varnish/default.vcl \
+           -v /LOCAL/PATH/TO/default.vcl:/etc/varnish/default.vcl \
+           -Pit --name=varnish-alpine thiagofigueiro/varnish-alpine-docker
+```
+
 Build image locally:
 
 ```bash

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 mkdir -p /var/lib/varnish/`hostname` && chown nobody /var/lib/varnish/`hostname`
-varnishd -s malloc,${VARNISH_MEMORY} -a :80 -b ${VARNISH_BACKEND_ADDRESS}:${VARNISH_BACKEND_PORT}
+if [ -n "${VARNISH_CONFIG_FILE}" ]; then
+  varnishd -s malloc,${VARNISH_MEMORY} -a :80 -f ${VARNISH_CONFIG_FILE}
+else
+  varnishd -s malloc,${VARNISH_MEMORY} -a :80 -b ${VARNISH_BACKEND_ADDRESS}:${VARNISH_BACKEND_PORT}
+fi
+
 sleep 1
 varnishlog


### PR DESCRIPTION
Have multiple separate docker contains running wordpress and needed the ability to read the host names and send them to different backends